### PR TITLE
Modify neuron package with python support

### DIFF
--- a/patch-nixpkgs/default.nix
+++ b/patch-nixpkgs/default.nix
@@ -8,43 +8,43 @@ let
     MergePkgs = with MergePkgs;  std-pkgs // patches;
     patches = with patches; with MergePkgs; rec {
 
-		  ## patch version of HDF5 with 
-		  # cpp bindigns enabled        
-		  hdf5-cpp = callPackage ./hdf5 {
-			szip = null;
-			mpi = null;
-			enableCpp = true;
-		  };
-		  
-		  ## enforce thread safety
-		  hdf5 =  std-pkgs.hdf5.overrideDerivation  ( oldAttrs:{
-					configureFlags = oldAttrs.configureFlags + " --enable-threadsafe ";
-		  });        
+          ## patch version of HDF5 with 
+          # cpp bindigns enabled        
+          hdf5-cpp = callPackage ./hdf5 {
+            szip = null;
+            mpi = null;
+            enableCpp = true;
+          };
+          
+          ## enforce thread safety
+          hdf5 =  std-pkgs.hdf5.overrideDerivation  ( oldAttrs:{
+                    configureFlags = oldAttrs.configureFlags + " --enable-threadsafe ";
+          });        
 
-		  slurm-llnl = std-pkgs.stdenv.lib.overrideDerivation std-pkgs.slurm-llnl ( oldAttrs: {
-			name = oldAttrs.name + "-bbp";
-		
-                        configureFlags = oldAttrs.configureFlags + " --sysconfdir=/etc/slurm ";	
-	
-		 });
-		
-		  ## 
-		  # mvapich2 mpi implementation
-		  #
-		  mvapich2 = callPackage ./mvapich2 {
-			slurm = slurm-llnl;	
-		  };
+          slurm-llnl = std-pkgs.stdenv.lib.overrideDerivation std-pkgs.slurm-llnl ( oldAttrs: {
+            name = oldAttrs.name + "-bbp";
+        
+                        configureFlags = oldAttrs.configureFlags + " --sysconfdir=/etc/slurm "; 
+    
+         });
+        
+          ## 
+          # mvapich2 mpi implementation
+          #
+          mvapich2 = callPackage ./mvapich2 {
+            slurm = slurm-llnl; 
+          };
 
-		  libnss-native-plugins = callPackage ./nss-plugin {
+          libnss-native-plugins = callPackage ./nss-plugin {
 
 
-		  };
+          };
 
-		 environment-modules =  callPackage ./env-modules { 
-			tcl = tcl-8_5;
-		 };
-		 
-		 envModuleGen = callPackage ./env-modules/generator.nix;
+         environment-modules =  callPackage ./env-modules { 
+            tcl = tcl-8_5;
+         };
+         
+         envModuleGen = callPackage ./env-modules/generator.nix;
 
     };
        


### PR DESCRIPTION
- Enable python support in nneuron for non BGQ platforms
- Move python path of neuron from /lib/python to the standard python path
- normalize some fiels indentation