### PR TITLE
Update the compilation script of PETsc and fixes following issues

### DIFF
--- a/bbp-nixpkgs/all.nix
+++ b/bbp-nixpkgs/all.nix
@@ -32,6 +32,13 @@ let
 
 		inherit bbp-mpi;
 
+		## override component that need bbp-mpi
+		petsc = pkgs.petsc.override {
+			mpiRuntime = bbp-mpi;
+		};
+
+	
+
 		##
 		## git / cmake external for viz components
 		##
@@ -139,14 +146,16 @@ let
 
 
 		neuron-modl = callPackage ./hpc/neuron {
+			stdenv = (keepDebugInfo stdenv);
 			mpiRuntime = null;
 			modlOnly = true;
 		};
 
 		neuron = enableBGQ callPackage ./hpc/neuron {
-		mpiRuntime = bbp-mpi;
-		nrnOnly = true;
-		nrnModl = mergePkgs.neuron-modl;
+			stdenv = (keepDebugInfo stdenv);
+			mpiRuntime = bbp-mpi;
+			nrnOnly = true;
+			nrnModl = mergePkgs.neuron-modl;
 		};
 
 

--- a/patch-nixpkgs/default.nix
+++ b/patch-nixpkgs/default.nix
@@ -102,26 +102,26 @@ let
 
 	};
 
-        ## PETSc utility toolkit
-        #
-        petsc = callPackage ./petsc {
-            mpiRuntime = mpich2;
-	    blas = openblas;
-        };
+    ## PETSc utility toolkit
+    #
+    petsc = callPackage ./petsc {
+	        mpiRuntime = pkgs.openmpi;
+			blas = openblas;
+    };
 
 	## profiling tools        
-        papi = callPackage ./papi {
+    papi = callPackage ./papi {
 
-        };        
+    };        
 
-        hpctoolkit = callPackage ./hpctoolkit {
-            papi = papi;
-        };
+    hpctoolkit = callPackage ./hpctoolkit {
+          papi = papi;
+    };
 
 	## env modules
-        environment-modules =  callPackage ./env-modules { 
+    environment-modules =  callPackage ./env-modules { 
             tcl = tcl-8_5;
-        };
+    };
 
         envModuleGen = callPackage ./env-modules/generator.nix;
 

--- a/patch-nixpkgs/petsc/default.nix
+++ b/patch-nixpkgs/petsc/default.nix
@@ -10,6 +10,11 @@ python
 }:
 
 
+let 
+	optFlags = "-g -O2 -ftree-vectorize";
+
+in
+
 stdenv.mkDerivation rec {
   name = "PETSc-${version}";
   version = "3.7";
@@ -31,6 +36,8 @@ stdenv.mkDerivation rec {
 
   configureOpts = [
                          "--with-fc=0"
+						 "COPTFLAGS='${optFlags}'"
+						 "CXXOPTFLAGS='${optFlags}'"
                   ];
 
 
@@ -44,6 +51,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ blas liblapack mpiRuntime];
    
+
+  buildFlags = [ "V=1"  ];
 
   ## cross compilation for Super-computer environments
   ##


### PR DESCRIPTION
- PETsc not compiled with mvapich2 on viz cluster
- PETsc not enabling correct compilation flag by default