### PR TITLE
Add support for frontend openblas on powerpc64

### DIFF
--- a/bluegene/config.nix
+++ b/bluegene/config.nix
@@ -50,6 +50,12 @@ bgq-config = rec {
         };
 
 
+    openblas = {
+		preferLocalBuild = true;
+		flags = [ "NUM_THREADS=64" "TARGET=POWER7" ];
+	};
+
+	isBlueGene = true;
 
 	};
 

--- a/bluegene/default.nix
+++ b/bluegene/default.nix
@@ -405,8 +405,6 @@ let
 		stdenv = bgq-stdenv;
 		stdenv-gcc47 = bgq-stdenv-gcc47;
 		boost = bgq-boost;
-		python = bgq-python27-gcc47;
-		pythonPackages = bgq-pythonPackages-gcc47;
 		blas = MergePkgs.blis;
 	};
 


### PR DESCRIPTION
required in order to have python + numpy on BGQ frontend