### PR TITLE
- Update Brayns with new Ospray and decoupled embree

### DIFF
--- a/bbp/default.nix
+++ b/bbp/default.nix
@@ -134,6 +134,10 @@ let
 
         };
 
+        cppnetlib = callPackage ./viz/cppnetlib {
+
+        };
+
         zeroeq = callPackage ./viz/zeroeq {
 
         };
@@ -173,6 +177,10 @@ let
         rtneuron = callPackage ./viz/rtneuron {   
 
         };  
+
+        embree = callPackage ./viz/embree {
+
+        };
 
         ospray = callPackage ./viz/ospray {
 

--- a/bbp/modules/default.nix
+++ b/bbp/modules/default.nix
@@ -845,7 +845,18 @@ let
             conflicts = conflicts-modules;
         };
 
+        tbb = pkgs.envModuleGen rec {
+            name = "tbb";
+            isLibrary = true;
+            setRoot = "TBB";
+            description = "TBB (Thread Building Block) Library ";
+            packages = [
+                            pkgs.tbb 
 
+                        ];
+            conflicts = conflicts-modules;
+    
+        };
 
 
         gcc52 = pkgs.envModuleGen rec {
@@ -943,6 +954,7 @@ let
                             ncurses
                             gldev
                             freetype
+                            tbb 
 
         ];
 
@@ -1018,6 +1030,9 @@ let
             cmake readline ncurses
             python27-light python27-full 
             cython 
+
+            # parallel
+            tbb 
 
             # wrapper for auth
             nss-wrapper 
@@ -1381,6 +1396,7 @@ with generic-modules; rec {
 
       bgq-dev-env-pkgs-gcc = [
         hdf5 libxml2 bison flex boost zlib openblas bgq-ibm-mpi bgq-cmake 
+        
       ];
 
       bgq-dev-env-gcc = pkgs.envModuleGen rec {

--- a/bbp/viz/brayns/default.nix
+++ b/bbp/viz/brayns/default.nix
@@ -5,6 +5,7 @@
 , boost
 , assimp ? null
 , ospray
+, embree 
 , freeglut
 , libXmu
 , libXi
@@ -35,14 +36,15 @@ stdenv.mkDerivation rec {
 
 	src = fetchgitExternal {
 		url  = "https://github.com/BlueBrain/Brayns.git";
-		rev = "8e7bad24202163a7073f8c5a4530eb79c82b68c3";
-		sha256 = "08nwgmb23imfgp1a2yv5nbc15rihjmjbbcrr3q8y4fjp0pd3420a";
+		rev = "80b143251c4b8b366e2e959b8b73e124d6e1d314";
+		sha256 = "18v4lk3rinvdh63xjpcm32kc22nljp8y9mzbd1cgmbpx1742j9bh";
 	};
 
 
 	cmakeFlags = [ 
 				"-DOSPRAY_ROOT=${ospray}"
 				"-DBRAYNS_REST_ENABLED=${if restInterface then "TRUE" else "FALSE"}" 
+                "-DEMBREE_ROOT=${embree}"
 				## horrible hack to solve
 				## this idiotic -WError at release time....
 				"-DXCODE_VERSION=1" ];

--- a/bbp/viz/cppnetlib/default.nix
+++ b/bbp/viz/cppnetlib/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, openssl
+, boost 
+}:
+
+
+stdenv.mkDerivation rec {
+    name = "cppnetlib-${version}";
+    version = "0.11-bbp";
+
+    src = fetchFromGitHub {
+        owner = "BlueBrain";
+        repo = "cpp-netlib";
+        rev = "ed0b1b65d122a184df8f1a0b2fb3d6ec594229dc";
+        sha256 = "1rfyf3px827bf4d1y1bhbkih7y1bfhkbyry537nkzvrrskhz58sc";
+    };
+    
+
+    buildInputs = [ cmake boost openssl ];
+
+
+
+}
+
+

--- a/bbp/viz/embree/default.nix
+++ b/bbp/viz/embree/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, ispc
+, tbb
+, freeglut 
+, mesa
+, libpng 
+, libXmu
+, libXi
+, imagemagick
+}:
+
+
+stdenv.mkDerivation rec {
+    name = "embree-${version}";
+    version = "2.12.0";
+
+    src = fetchFromGitHub {
+        owner = "embree";
+        repo = "embree";
+        rev = "39d72c4f8ebebbe42c6f5427443c27e7cf6c3529";
+        sha256 = "0fklln76pjqiha5av4wzk25vaialqhf1ws58i75vbs8qdyxxnsm8";
+    };
+    
+
+    buildInputs = [ cmake ispc tbb freeglut 
+                    mesa libpng libXmu libXi imagemagick ];
+
+
+
+}
+
+

--- a/bbp/viz/lexis/default.nix
+++ b/bbp/viz/lexis/default.nix
@@ -7,15 +7,15 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "lexis-1.12.0";
+  name = "lexis-1.1.0-2017";
   buildInputs = [ stdenv boost zeroeq zerobuf ];
   nativeBuildInputs = [ cmake zerobuf.python ];
 
 
   src = fetchgitExternal {
     url = "https://github.com/HBPVIS/Lexis.git";
-    rev = "c24dc078337d0c6f65ab057178bd7d9d655732ee";
-    sha256 = "1qhi41an0b7vi5jl0fvaq7q5ivqgjnfgbh6d9xj8vq5v17hhqj8v";
+    rev = "1d70690282408f5e8513d9e05c72851988822177";
+    sha256 = "1s8fmk1amry5fswvfy8ansj22656f08rldkar4rs1cid57q4py2l";
   };
   
   enableParallelBuilding = true;

--- a/bbp/viz/ospray/default.nix
+++ b/bbp/viz/ospray/default.nix
@@ -3,33 +3,44 @@
 , cmake
 , pkgconfig
 , ispc
-, tbb 
+, embree
 , doxygen
-, mesa 
+, tbb
+, mesa
 , freeglut
+, readline
 , qt4
 }:
 
 
 stdenv.mkDerivation rec {
 	name = "ospray-${version}";
-	version = "0.1.0";
+	version = "1.1.2";
 
-	buildInputs = [ pkgconfig ispc tbb mesa freeglut qt4 ];
+	buildInputs = [ pkgconfig embree tbb ispc mesa freeglut readline qt4 ];
 
 	nativeBuildInputs = [ doxygen cmake ];
 
 	src = fetchFromGitHub {
-		owner = "BlueBrain";
-		repo  = "OSPRay";
-		rev = "e443fd76f2249a55bf7365d0411545693c1856f6";
-		sha256 = "02waiw40b8pml27pdxxpg6b510m4vay2c0w6fs44d2dj3yqkh2f2";
+		owner = "ospray";
+		repo  = "ospray";
+		rev = "95ccc33fa023e9d3bc51253980dd1fa18215963b";
+		sha256 = "0f1zjdpgx7hda3swlm2mr2acr24fb4f70y2bnqpdlsi3ns4p88wi";
 	};
+
+
+
+    cmakeFlags = [ "-DOSPRAY_USE_EXTERNAL_EMBREE=TRUE"      # disable bundle embree
+                   "-DOSPRAY_ZIP_MODE=OFF"                   #disable bundle dependencies
+                   "-Dembree_DIR=${embree}" 
+                   "-DEMBREE_MAX_ISA=AVX2"
+                   "-DTBB_ROOT=${tbb}"
+                   ];
 
 
 	outputs = [ "out" "doc" ];
 
-    propagatedBuildInputs = [ ispc ];
+    propagatedBuildInputs = [ ispc  embree ];
 
 	enableParallelBuilding = true;
 

--- a/bbp/viz/servus/default.nix
+++ b/bbp/viz/servus/default.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation rec {
 
   src = fetchgitExternal {
     url = "https://github.com/HBPVIS/Servus.git";  
-    rev = "5afd636b117aa3b046bf06ae5864ec1ce5e4e497";
-    sha256 = "0rfanhxwr61q3q8mkfnd3xfv2v254zffkzg518b7cdrhhsfaa9fx";
+    rev = "2da95eab05b830d224f44a6d8a0a91f06ea8e534";
+    sha256 = "11dgwmjd9pcnz3py761ibsfivk9yivkh30v40pgydilrp6gm5f20";
   };
   
 

--- a/bbp/viz/zerobuf/default.nix
+++ b/bbp/viz/zerobuf/default.nix
@@ -11,15 +11,15 @@ let
 in
 stdenv.mkDerivation rec {
   name = "zerobuf-${version}";
-  version = "0.3.0-2016-09";
+  version = "0.4-2017";
 
   buildInputs = [ stdenv pkgconfig servus cmake python-env boost ];
 
 
   src = fetchgitExternal{
     url = "https://github.com/HBPVIS/ZeroBuf.git";
-    rev = "346c1b5a355542ed084600460b96f67f347797e9";
-    sha256 = "0immzcfzhvx2mxrblsh4892qcl1alqx5qpyrz1r6xqcki6yh92yl";
+    rev = "f40a6e46fae17aa54f54f65047a227b37843c993";
+    sha256 = "06m1khj0pgl5ndfij8lfnk4nfncxppp5ns68ws68caaz5pf0zh4s";
   };
   
   enableParallelBuilding = false;

--- a/bbp/viz/zeroeq/default.nix
+++ b/bbp/viz/zeroeq/default.nix
@@ -6,6 +6,8 @@
 , httpxx
 , zeromq
 , boost 
+, openssl
+, cppnetlib
 }:
 
 
@@ -13,14 +15,14 @@ stdenv.mkDerivation rec {
   name = "zeroeq-${version}";
   version = "0.6.0-2016-10";
 
-  buildInputs = [ stdenv pkgconfig servus cmake boost httpxx zeromq ];
+  buildInputs = [ stdenv pkgconfig servus cmake boost httpxx zeromq openssl cppnetlib ];
 
 
 
   src = fetchgitExternal{
-    url = "https://github.com/HBPVIS/ZeroEQ.git";
-    rev = "1ff42dc1441260615ae93e89f254f5a40077b7df";
-    sha256 = "0lczv7baq5kmpb4naknvq0bgiwbapp1fdj9aqsn5zax9j6sxhjwd";
+    url = "https://github.com/adevress/ZeroEQ.git";
+    rev = "5248ae1af4add18dae496c80e20116714580c7f6";
+    sha256 = "0bynw78chq1ss8wg687q8ffb06pa1sbwv0i6f1g5q5al6jzd6wxi";
   };
   
   preConfigure = ''
@@ -28,6 +30,9 @@ stdenv.mkDerivation rec {
 			export CPPFLAGS="-fPIC $CPPFLAGS"
 			export CXXFLAGS="-fPIC $CXXFLAGS"
   '';
+
+  
+  cmakeFlags = [ "-DZEROEQ_USE_EXTERNAL_CPPNETLIB=TRUE" ];
 
   makeFlags = [ "VERBOSE=1" ];
 

--- a/patches/default.nix
+++ b/patches/default.nix
@@ -290,6 +290,10 @@ let
 
         };
 
+        tbb = callPackage ./tbb {
+
+        };
+
     };
 
     additionalPythonPackages = MergePkgs.callPackage ./additionalPythonPackages ({

--- a/patches/tbb/default.nix
+++ b/patches/tbb/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation {
+  name = "tbb-2017";
+
+  src = fetchurl {
+    url = "https://www.threadingbuildingblocks.org/sites/default/files/software_releases/source/tbb2017_20161128oss_src.tgz";
+    sha256 = "0h55h108az3ygarpcs4ys4b46cbr1f3my70aacs0xsn86di1c2f0";
+  };
+
+  checkTarget = "test";
+  doCheck = false;
+
+  installPhase = ''
+    mkdir -p $out/{lib,share/doc}
+    cp "build/"*release*"/"*so* $out/lib/
+    mv include $out/
+    rm $out/include/index.html
+    mv doc/html $out/share/doc/tbb
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Intel Thread Building Blocks C++ Library";
+    homepage = "http://threadingbuildingblocks.org/";
+    license = stdenv.lib.licenses.lgpl3Plus;
+    longDescription = ''
+      Intel Threading Building Blocks offers a rich and complete approach to
+      expressing parallelism in a C++ program. It is a library that helps you
+      take advantage of multi-core processor performance without having to be a
+      threading expert. Intel TBB is not just a threads-replacement library. It
+      represents a higher-level, task-based parallelism that abstracts platform
+      details and threading mechanisms for scalability and performance.
+    '';
+    platforms = stdenv.lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
- Add embree as a separated library
- Add TBB in last 2017 version used by ospray and embree
- Update Ospray to recent version
- Update Lexis to more recent version ( API break )
- Update ZeroBuf to more recent version ( API break )
- Update servus to more recent version
- Update ZeroEQ to more recent version
- Patch ZeroEQ
- Introduce cppnetlib-bpp, new dependency of zeroEQ