### PR TITLE
Enable NEURON's multi-send spike exchange implementation.

### DIFF
--- a/bbp/hpc/neuron/default.nix
+++ b/bbp/hpc/neuron/default.nix
@@ -34,12 +34,14 @@ let
                             "--without-iv" 
                             "--without-memacs" 
                             "--with-paranrn"
+                            "--with-multisend"
                             "--without-nmodl"
                             "--host=powerpc64"
                             "--with-nrnpython"
                         ]
                      else [ 
                             "--with-paranrn" 
+                            "--with-multisend"
                             "--without-iv" "--without-nmodl" 
                             "--with-nrnpython=${python}/bin/python"
                           ];


### PR DESCRIPTION
It's fine to enable this option for all configurations/builds.