### PR TITLE
morpho-tool: update expected src hash

### DIFF
--- a/bbp/hpc/morphotool/default.nix
+++ b/bbp/hpc/morphotool/default.nix
@@ -32,7 +32,7 @@ in
     src = fetchgitPrivate {
       url = "git@github.com:BlueBrain/morpho-tool.git";
       rev = "3b2682747f4544fdc22742fee1249b3870fb0ce9";
-      sha256 = "0ss36andarxy4i9jp8fih51irbbvyyazr3g771rrqw8biimgzzqm";
+      sha256 = "09xyjvyjfj522203vwaapc5f5d1jp6z55bivjibvzzj0aaafl63c";
       leaveDotGit = true;  # required by setuptools_scm Python module
     };
 


### PR DESCRIPTION
I do not understand why the expected hash has suddenly changed:
https://bbpcode.epfl.ch/ci/view/hpc/job/hpc.release.documentation/platform=nix/3/console

Any idea @adevress ?