### PR TITLE
Refactor completely the way to build neuron by

### DIFF
--- a/bbp/default.nix
+++ b/bbp/default.nix
@@ -450,17 +450,10 @@ let
         };
 
 
-        neuron-modl = callPackage ./hpc/neuron {
-            stdenv = (enableDebugInfo pkgsWithBGQXLC.stdenv);
-            mpiRuntime = null;
-            modlOnly = true;
-        };
-
         neuron = enableBGQ callPackage ./hpc/neuron {
             stdenv = (enableDebugInfo pkgsWithBGQXLC.stdenv);
             mpiRuntime = bbp-mpi;
-            nrnOnly = true;
-            nrnModl = mergePkgs.neuron-modl;
+            isBlueGene = pkgs.isBlueGene;
         };
 
 

--- a/bbp/hpc/neuron/bgq.nix
+++ b/bbp/hpc/neuron/bgq.nix
@@ -1,0 +1,144 @@
+{
+stdenv,
+neuron-src,
+autoconf,
+automake,
+libtool,
+mpiRuntime,
+ncurses,
+readline,
+flex,
+bison,
+python,
+pythonVersion ? "2.7",
+which,
+modlOnly ? false,
+nrnOnly ? false,
+nrnModl ? null,
+...
+}:
+
+assert modlOnly -> (nrnOnly == false);
+assert nrnOnly -> (modlOnly == false);
+assert nrnOnly -> (nrnModl != null);
+
+
+let 
+    isBGQ = true;
+
+    modlOnlyFlags = "--with-nmodl-only --without-x --without-memacs ";
+
+    nrnOnlyFlags = [ 
+                            "--enable-bluegeneQ" 
+                            "--without-iv" 
+                            "--without-memacs" 
+                            "--with-paranrn"
+                            "--with-multisend"
+                            "--without-nmodl"
+                            "--host=powerpc64"
+                            "--with-nrnpython"
+    ];
+
+    platformPreConfigure = if (isBGQ && nrnOnly) then ''
+                                        ## BGQ specific neuron preconfiguration 
+                                        export CC=mpixlc_r
+                                        export CXX=mpixlcxx_r
+
+                                        export NEURON_PYTHON_VERSION="${pythonVersion}"
+                                        export ALL_FLAGS="-qnostaticlink -DLAYOUT=0 -DDISABLE_HOC_EXP -DDISABLE_TIMEOUT -O3 -g -DCORENEURON_BUILD -qlist -qsource -qreport -qsmp=noauto -qthreaded";
+                                        export CXXFLAGS="$ALL_FLAGS $CXXFLAGS"
+                                        export CFLAGS="$ALL_FLAGS  $CFLAGS";
+
+                                        export PYINCDIR="${python}/include/python${pythonVersion}" 
+                                        export PYLIB="-L${python}/lib -lpython${pythonVersion}"
+                                        export PYLIBDIR="${python}/lib"
+                                        export PYLIBLINK="-L${python}/lib -lpython${pythonVersion}"
+                                   ''
+                                    else '''';
+
+in 
+stdenv.mkDerivation rec {
+    name = "neuron-${version}-BBP-${if modlOnly then "modl" else if nrnOnly then "nrn" else "all"}";
+
+    versionMajor = neuron-src.info.versionMajor;
+    versionMinor = neuron-src.info.versionMinor;
+    versionDate = neuron-src.info.versionDate;
+
+    version = "${versionMajor}.${versionMinor}-dev${versionDate}";
+
+    buildInputs = [ automake autoconf libtool mpiRuntime ncurses readline flex bison python which nrnModl];
+
+
+	patches = [ ./nrn.patch ];
+
+    src = neuron-src.srcs; 
+
+
+## neuron configure its version number from commit number.
+## Consequently it fails to build if no VCS have been used
+## to checkout the source. This need to be fixed
+postPatch = ''
+cat  > src/nrnoc/nrnversion.h << EOF
+#define NRN_MAJOR_VERSION "${versionMajor}"
+#define NRN_MINOR_VERSION "${versionMinor}"
+#define GIT_DATE "${versionDate}"
+#define GIT_BRANCH "master"
+#define GIT_CHANGESET "${neuron-src.info.rev}"
+#define GIT_TREESET "${neuron-src.info.rev}"
+#define GIT_LOCAL "NOT_YET_SUPPORTED"
+#define GIT_TAG "NOT_YET_SUPPORTED"
+EOF
+
+'';
+
+    ## run the pre-configure neuron script
+    ## and force the exec prefix to the absolute install dir
+    preConfigure = platformPreConfigure +
+                    ''
+                    ./build.sh
+                    export configureFlags="''${configureFlags} --exec-prefix=''${out}"
+                    '';
+
+
+
+    configureFlags =   (if modlOnly then modlOnlyFlags
+                            else if nrnOnly then nrnOnlyFlags
+                            else " --with-paranrn --without-iv ");
+
+    makeFlags = " ${if nrnOnly then "NMODL=${nrnModl}/bin/nocmodl" else "" } ";
+
+
+    enableParallelBuilding = true;  
+
+    ## remove duplicated libtool / autotools files
+    postInstall = if modlOnly then
+''
+rm -rf $out/share/nrn/libtool
+rm -rf $out/*/lib/nrnconf.h
+''
+else if nrnOnly then
+''
+ln -s ${nrnModl}/bin/modlunit $out/bin/modlunit
+ln -s ${nrnModl}/bin/nocmodl $out/bin/nocmodl
+
+## standardise python neuron install dir if any
+if [[ -d $out/lib/python ]]; then
+    LOCAL_PYTHONVER="$(python -c "from distutils.sysconfig import get_python_version; print(get_python_version())")"
+    LOCAL_PYTHONDIR="$out/lib/python''${LOCAL_PYTHONVER}"
+    mkdir -p ''${LOCAL_PYTHONDIR}
+    mv ''${out}/lib/python ''${LOCAL_PYTHONDIR}/site-packages
+fi
+''
+else
+'' 
+'';   
+
+    propagatedBuildInputs = [ readline which libtool ];
+
+    passthru = {
+        # we have no GUI on BGQ
+        iv = null;
+    };
+        
+    
+}

--- a/bbp/hpc/neuron/default.nix
+++ b/bbp/hpc/neuron/default.nix
@@ -1,29 +1,13 @@
 {
 stdenv,
 fetchFromGitHub,
-autoconf,
-automake,
-libtool,
-mpiRuntime,
-ncurses,
-readline,
-flex,
-bison,
-python,
-pythonVersion ? "2.7",
-which,
-modlOnly ? false,
-nrnOnly ? false,
-nrnModl ? null
-}:
+callPackage,
+isBlueGene,
+... } @ args:
 
-assert modlOnly -> (nrnOnly == false);
-assert nrnOnly -> (modlOnly == false);
-assert nrnOnly -> (nrnModl != null);
+let
 
-
-let 
-    neuron-src = {
+    neuron-info = {
         versionMajor = "7";
         versionMinor = "5";
         versionDate = "2017-08-06";
@@ -31,130 +15,44 @@ let
         sha256 = "0msca5q8yf42scmgfj932vbhzs57yaiy11hydr4vy9zhnzp5kk8r";
     };
 
+    neuron-src = rec {
+        info = neuron-info;
 
-    isBGQ = if builtins.hasAttr "isBlueGene" stdenv == true
-            then builtins.getAttr "isBlueGene" stdenv else false;
-
-    modlOnlyFlags = "--with-nmodl-only --without-x --without-memacs ";
-
-    nrnOnlyFlags =  if isBGQ then 
-                        [ 
-                            "--enable-bluegeneQ" 
-                            "--without-iv" 
-                            "--without-memacs" 
-                            "--with-paranrn"
-                            "--with-multisend"
-                            "--without-nmodl"
-                            "--host=powerpc64"
-                            "--with-nrnpython"
-                        ]
-                     else [ 
-                            "--with-paranrn" 
-                            "--with-multisend"
-                            "--without-iv" "--without-nmodl" 
-                            "--with-nrnpython=${python}/bin/python"
-                          ];
-
-    platformPreConfigure = if (isBGQ && nrnOnly) then ''
-                                        ## BGQ specific neuron preconfiguration 
-                                        export CC=mpixlc_r
-                                        export CXX=mpixlcxx_r
-
-                                        export NEURON_PYTHON_VERSION="${pythonVersion}"
-                                        export ALL_FLAGS="-qnostaticlink -DLAYOUT=0 -DDISABLE_HOC_EXP -DDISABLE_TIMEOUT -O3 -g -DCORENEURON_BUILD -qlist -qsource -qreport -qsmp=noauto -qthreaded";
-                                        export CXXFLAGS="$ALL_FLAGS $CXXFLAGS"
-                                        export CFLAGS="$ALL_FLAGS  $CFLAGS";
-
-                                        export PYINCDIR="${python}/include/python${pythonVersion}" 
-                                        export PYLIB="-L${python}/lib -lpython${pythonVersion}"
-                                        export PYLIBDIR="${python}/lib"
-                                        export PYLIBLINK="-L${python}/lib -lpython${pythonVersion}"
-                                   ''
-                                    else '''';
-
-in 
-stdenv.mkDerivation rec {
-    name = "neuron-${version}-BBP-${if modlOnly then "modl" else if nrnOnly then "nrn" else "all"}";
-
-    versionMajor = neuron-src.versionMajor;
-    versionMinor = neuron-src.versionMinor;
-    versionDate = neuron-src.versionDate;
-
-    version = "${versionMajor}.${versionMinor}-dev${versionDate}";
-
-    buildInputs = [ automake autoconf libtool mpiRuntime ncurses readline flex bison python which nrnModl];
-
-
-	patches = [ ./nrn.patch ];
-
-    src = fetchFromGitHub {
-		owner = "nrnhines";
-		repo = "nrn";
-        rev = neuron-src.rev;
-        sha256 = neuron-src.sha256;
+        srcs = fetchFromGitHub {
+            owner = "nrnhines";
+            repo = "nrn";
+            rev = info.rev;
+            sha256 = info.sha256;
+        };
     };
 
+    interview = callPackage ./interview.nix ( args // rec {
+
+    });
+
+    # compile neuron on BGQ is journey
+    # where neuron need to be compiled twice
+    bgq-neuron-modl = callPackage ./bgq.nix (args // rec {
+        mpiRuntime = null;
+        modlOnly = true;
+        inherit neuron-src;
+    });
+
+    bgq-neuron-nrn =  callPackage ./bgq.nix ( args // rec {
+        nrnModl = bgq-neuron-modl;
+        nrnOnly = true;
+        inherit neuron-src;
+    });
 
 
-## neuron configure its version number from commit number.
-## Consequently it fails to build if no VCS have been used
-## to checkout the source. This need to be fixed
-postPatch = ''
-cat  > src/nrnoc/nrnversion.h << EOF
-#define NRN_MAJOR_VERSION "${versionMajor}"
-#define NRN_MINOR_VERSION "${versionMinor}"
-#define GIT_DATE "${versionDate}"
-#define GIT_BRANCH "master"
-#define GIT_CHANGESET "${neuron-src.rev}"
-#define GIT_TREESET "${neuron-src.rev}"
-#define GIT_LOCAL "NOT_YET_SUPPORTED"
-#define GIT_TAG "NOT_YET_SUPPORTED"
-EOF
+    neuron-generic = callPackage ./generic.nix ( args // rec {
+        inherit neuron-src;
+        inherit interview;
+    });
 
-'';
-
-    ## run the pre-configure neuron script
-    ## and force the exec prefix to the absolute install dir
-    preConfigure = platformPreConfigure +
-                    ''
-                    ./build.sh
-                    export configureFlags="''${configureFlags} --exec-prefix=''${out}"
-                    '';
+in
+    if (isBlueGene) then bgq-neuron-nrn else neuron-generic
 
 
 
-    configureFlags =   (if modlOnly then modlOnlyFlags
-                            else if nrnOnly then nrnOnlyFlags
-                            else " --with-paranrn --without-iv ");
 
-    makeFlags = " ${if nrnOnly then "NMODL=${nrnModl}/bin/nocmodl" else "" } ";
-
-
-    enableParallelBuilding = true;  
-
-    ## remove duplicated libtool / autotools files
-    postInstall = if modlOnly then
-''
-rm -rf $out/share/nrn/libtool
-rm -rf $out/*/lib/nrnconf.h
-''
-else if nrnOnly then
-''
-ln -s ${nrnModl}/bin/modlunit $out/bin/modlunit
-ln -s ${nrnModl}/bin/nocmodl $out/bin/nocmodl
-
-## standardise python neuron install dir if any
-if [[ -d $out/lib/python ]]; then
-    LOCAL_PYTHONVER="$(python -c "from distutils.sysconfig import get_python_version; print(get_python_version())")"
-    LOCAL_PYTHONDIR="$out/lib/python''${LOCAL_PYTHONVER}"
-    mkdir -p ''${LOCAL_PYTHONDIR}
-    mv ''${out}/lib/python ''${LOCAL_PYTHONDIR}/site-packages
-fi
-''
-else
-'' 
-'';   
-
-    propagatedBuildInputs = [ readline which libtool ];
-    
-}

--- a/bbp/hpc/neuron/generic.nix
+++ b/bbp/hpc/neuron/generic.nix
@@ -1,0 +1,86 @@
+{
+stdenv,
+neuron-src,
+autoconf,
+automake,
+libtool,
+mpiRuntime,
+ncurses,
+readline,
+flex,
+bison,
+python,
+interview,
+which,
+...
+}:
+
+stdenv.mkDerivation rec {
+    name = "neuron-${version}-BBP";
+
+    versionMajor = neuron-src.info.versionMajor;
+    versionMinor = neuron-src.info.versionMinor;
+    versionDate = neuron-src.info.versionDate;
+
+    version = "${versionMajor}.${versionMinor}-dev${versionDate}";
+
+    buildInputs = [ automake autoconf libtool mpiRuntime ncurses readline flex bison python which interview];
+
+
+	patches = [ ./nrn.patch ];
+
+    src = neuron-src.srcs;
+
+## neuron configure its version number from commit number.
+## Consequently it fails to build if no VCS have been used
+## We give him a commit version manually defined
+postPatch = ''
+    cat  > src/nrnoc/nrnversion.h << EOF
+    #define NRN_MAJOR_VERSION "${versionMajor}"
+    #define NRN_MINOR_VERSION "${versionMinor}"
+    #define GIT_DATE "${versionDate}"
+    #define GIT_BRANCH "master"
+    #define GIT_CHANGESET "${neuron-src.info.rev}"
+    #define GIT_TREESET "${neuron-src.info.rev}"
+    #define GIT_LOCAL "NOT_YET_SUPPORTED"
+    #define GIT_TAG "NOT_YET_SUPPORTED"
+    EOF
+
+'';
+
+    ## run the pre-configure neuron script
+    ## and force the exec prefix to the absolute install dir
+    preConfigure = ''
+                    ./build.sh
+                    export configureFlags="''${configureFlags} --exec-prefix=''${out}"
+    '';
+
+
+
+    configureFlags = [
+                            "--with-paranrn"
+                            "--with-multisend"
+                            ''${if (interview != null) then ''--with-iv=${interview}'' else ''--without-iv''}''
+    ] 
+    ++ (stdenv.lib.optional) (python != null) [ "--with-nrnpython=${python}/bin/python" ];
+    
+
+
+    enableParallelBuilding = true;  
+
+    postInstall = '' 
+    ## standardise python neuron install dir if any
+    if [[ -d $out/lib/python ]]; then
+        LOCAL_PYTHONVER="$(python -c "from distutils.sysconfig import get_python_version; print(get_python_version())")"
+        LOCAL_PYTHONDIR="$out/lib/python''${LOCAL_PYTHONVER}"
+        mkdir -p ''${LOCAL_PYTHONDIR}
+        mv ''${out}/lib/python ''${LOCAL_PYTHONDIR}/site-packages
+    fi'';
+
+    propagatedBuildInputs = [ readline which libtool interview ];
+
+    passthru = {
+        iv = interview;
+    };
+    
+}

--- a/bbp/hpc/neuron/interview.nix
+++ b/bbp/hpc/neuron/interview.nix
@@ -1,0 +1,39 @@
+{
+stdenv,
+fetchFromGitHub,
+autoconf,
+automake,
+libtool,
+which,
+x11,
+...
+}:
+
+stdenv.mkDerivation rec {
+    name = "interview-${version}";
+    version = "0.1-trunk";
+    
+    src = fetchFromGitHub {
+        owner = "nrnhines";
+        repo = "iv";
+        rev = "76c123bdb3562b03745fd2d8734506bebfcaef29";
+        sha256 = "0glnk80gm27yh4x3zajqfca00q8kkkp1ir94xlr7izv6ns8n13hj";
+    };
+
+
+    buildInputs = [ autoconf automake libtool which x11 ];
+    propagatedBuildInputs = [ x11 ];
+
+    preConfigure = ''
+        ./build.sh
+
+        # remove the damn x86_64 prefix
+        export configureFlags="''${configureFlags} --exec-prefix=''${out}"
+
+        # enforce linking flags to X11, missing in michael configure
+        export LDFLAGS="-lX11" 
+    '';
+
+    enableParallelBuilding = true;
+
+}

--- a/bbp/modules/default.nix
+++ b/bbp/modules/default.nix
@@ -358,6 +358,7 @@ let
             packages =
             [
                 pkgs.neuron
+                pkgs.neuron.iv
                 pkgs.readline
                 pkgs.ncurses
             ];


### PR DESCRIPTION
- separating BGQ and normal configuration
- Add interview support for non-BGQ platforms
- Avoid two-pass compilation for non-BGQ platforms
- Enable interview by default