### PR TITLE
Fixes in HPC software documentation

### DIFF
--- a/bbp/common/vizDoc/builder.py
+++ b/bbp/common/vizDoc/builder.py
@@ -63,6 +63,11 @@ def lookup_dir(root, name):
 
 
 class Package(object):
+    MAINTAINERS_BLACK_LIST = {
+        'Florian Friesdorf <flo@chaoflow.net>',
+        'Domen Kozar <domen@dev.si>',
+    }
+
     """Documentation package
     """
     def __init__(self, pkg):
@@ -70,7 +75,7 @@ class Package(object):
 
     @property
     def name(self):
-        return self._pkg['name']
+        return self._get_meta_property('docname', default=self._pkg['name'])
 
     @property
     def meta(self):
@@ -108,7 +113,11 @@ class Package(object):
 
     @property
     def maintainers(self):
-        return self._get_meta_property('maintainers', [])
+        return [
+            maintainer for maintainer
+            in self._get_meta_property('maintainers', [])
+            if maintainer not in Package.MAINTAINERS_BLACK_LIST
+        ]
 
     @property
     def version(self):

--- a/bbp/hpc/functionalizer/default.nix
+++ b/bbp/hpc/functionalizer/default.nix
@@ -81,6 +81,9 @@ stdenv.mkDerivation rec {
     license = {
       fullName = "Copyright 2012, Blue Brain Project";
     };
+    maintainers = [
+      config.maintainers.jamesgkind
+    ];
   };
 
 

--- a/bbp/hpc/highfive/default.nix
+++ b/bbp/hpc/highfive/default.nix
@@ -1,5 +1,6 @@
 {
   boost,
+  config,
   cmake,
   fetchFromGitHub,
   hdf5,
@@ -54,6 +55,9 @@ stdenv.mkDerivation rec {
     platforms = stdenv.lib.platforms.all;
     homepage = https://github.com/BlueBrain/HighFive;
     license = stdenv.lib.licenses.boost;
+    maintainers = [
+      config.maintainers.adevress
+    ];
   };
 
 }

--- a/bbp/hpc/morphotool/default.nix
+++ b/bbp/hpc/morphotool/default.nix
@@ -40,6 +40,9 @@ in
       homepage = https://github.com/BlueBrain/morpho-tool;
       description = "Perform biological neuron morphologies operations";
       license = stdenv.lib.licenses.gpl2Plus;
+      maintainers = [
+        config.maintainers.adevress
+      ];
     };
 
     buildInputs = [

--- a/bbp/hpc/pytouchreader/default.nix
+++ b/bbp/hpc/pytouchreader/default.nix
@@ -20,6 +20,12 @@ let
       license = {
         fullName = "Copyright 2017, Blue Brain Project";
       };
+      maintainers = [
+        config.maintainers.ferdonline
+      ];
+      # Override documentation package name because
+      # buildPythonPackage prefix `name` by "pythonMAJOR.MINOR-"
+      docname = name;
     };
 
     src = fetchgitPrivate {

--- a/bbp/hpc/spykfunc/default.nix
+++ b/bbp/hpc/spykfunc/default.nix
@@ -42,11 +42,14 @@ in
         parallel hdf5 when available.
       '';
       platforms = stdenv.lib.platforms.unix;
-      homepage = "https://bbpcode.epfl.ch/code/#/admin/projects/building/Functionalizer";
+      homepage = "https://bbpteam.epfl.ch/project/spaces/display/BBPHPC/Spark+functionalizer";
       repository = "ssh://bbpcode.epfl.ch/building/Functionalizer";
       license = {
         fullName = "Copyright 2017, Blue Brain Project";
       };
+      maintainers = [
+        config.maintainers.ferdonline
+      ];
     };
     src = fetchgitPrivate {
       url = config.bbp_git_ssh + "/building/Functionalizer";

--- a/config/all_config.nix
+++ b/config/all_config.nix
@@ -1,16 +1,16 @@
+let
+  all_config_mods = {}
+  // (import ./ibm_bgq_config.nix)
+  // (import ./knl_platform_config.nix)
+  // (import ./intel_config.nix)
+  // (import ./cray_config.nix)
+  // (import ./allinea_config.nix)
+  // (import ./shared_config.nix)
+  // (import ./slurm_config.nix)
+  // (import ./bbp_maintainers_config.nix);
 
-let 
-  all_config_mods = {} // (import ./ibm_bgq_config.nix)
-			// (import ./knl_platform_config.nix)
-			// (import ./intel_config.nix) 
-			// (import ./cray_config.nix) 
-			// (import ./allinea_config.nix)
-			// (import ./shared_config.nix)
-			// (import ./slurm_config.nix);
-
-  packages_override = (import ./apply_override.nix { config = all_config_mods;} );
+  packages_override = (import ./apply_override.nix {
+    config = all_config_mods;
+  } );
 in
   all_config_mods // packages_override
-
-
-

--- a/config/bbp_maintainers_config.nix
+++ b/config/bbp_maintainers_config.nix
@@ -1,0 +1,18 @@
+{
+  maintainers = {
+    adevress = "Adrien Devresse <adrien.devresse@epfl.ch>";
+    brunomaga = "Bruno Magalhães <bruno.magalhaes@epfl.ch>";
+    delalond = "Fabien Delalondre <fabien.delalondre@epfl.ch>";
+    ferdonline = "Fernando Pereira <fernando.pereira@epfl.ch>";
+    fouriaux = "Jeremy Fouriaux <jeremy.fouriaux@epfl.ch>";
+    FrancescoCasalegno = "Casalegno Francesco <francesco.casalegno@epfl.ch>";
+    jamesgkind = "James Gonzalo King <jamesgonzalo.king@epfl.ch>";
+    jplanasc = "Judit Planas <judit.planas@epfl.ch>";
+    pramodskumbhar = "Kumbhar Pramod Shivaji <pramod.kumbhar@epfl.ch>";
+    sharkovsky = "Cremonesi Francesco <francesco.cremonesi@epfl.ch>";
+    shurikasa = "Ovcharenko Aleksandr <aleksandr.ovcharenko@epfl.ch>";
+    till = "Till Schumann <till.schumann@epfl.ch>";
+    timocafe = "Ewart Timothée <timothee.ewart@epfl.ch>";
+    tristan0x = "Tristan Carel <tristan.carel@epfl.ch>";
+  };
+}


### PR DESCRIPTION
* Add aliases for HPC maintainers
* Get rid of maintainers automatically added by
  `buildPythonPackage`
* New `docname` meta property to override package name
* Add maintainers to HPC documented softwares