### PR TITLE
Libtool lib nest

### DIFF
--- a/bbp/modules/default.nix
+++ b/bbp/modules/default.nix
@@ -1387,6 +1387,7 @@ let
                             pkgs.automake
                             pkgs.autoconf
                             pkgs.libtool
+                            pkgs.libtool.lib
                        ];
             conflicts = [ "autotools" ];
         };


### PR DESCRIPTION
- add libtool library back into the module list, required for nest