### PR TITLE
python-full: new packages

### DIFF
--- a/bbp/modules/default.nix
+++ b/bbp/modules/default.nix
@@ -1358,11 +1358,17 @@ let
                pkgs.bbp-virtualenv
                pythonPkgs.cython
                pythonPkgs.deepdish
+               pythonPkgs.docopt
+               pythonPkgs.freezegun
                pythonPkgs.enum34
                pythonPkgs.h5py
+               pythonPkgs.jinja2
                pythonPkgs.matplotlib
                pythonPkgs.pyparsing
+               pythonPkgs.pyyaml
+               pythonPkgs.requests
                pythonPkgs.seaborn
+               pythonPkgs.statsmodels
 
                # add all python3 backports in the same directory
                pythonPkgs.backports_functools_lru_cache
@@ -1422,10 +1428,16 @@ let
                pkgs.bbp-virtualenv-py3
                pythonPkgs.cython
                pythonPkgs.deepdish
+               pythonPkgs.docopt
+               pythonPkgs.freezegun
                pythonPkgs.h5py
+               pythonPkgs.jinja2
                pythonPkgs.matplotlib
                pythonPkgs.pyparsing
+               pythonPkgs.pyyaml
+               pythonPkgs.requests
                pythonPkgs.seaborn
+               pythonPkgs.statsmodels
 
                pythonPkgs.cycler
                pythonPkgs.numpy


### PR DESCRIPTION
Added the following packages to both Python 2 and Python 3 modules:
* docopt: Command-line interface description language
* freezegun: Let your Python tests travel through time
* jinja2: templating library
* pyyaml: YAML library
* requests: HTTP requests for human
* statsmodels: estimation of statistical models
