### PR TITLE
Add morphio and its python binding

### DIFF
--- a/bbp/default.nix
+++ b/bbp/default.nix
@@ -310,6 +310,12 @@ let
         neurom = callPackage ./nse/neurom {
         };
 
+        morphio-python = callPackage ./nse/morphio-python {
+        };
+
+        morphio = callPackage ./nse/morphio {
+        };
+
         bbp-morphology-workflow = callPackage ./nse/bbp-morphology-workflow {
         };
 

--- a/bbp/nse/morphio
+++ b/bbp/nse/morphio
@@ -1,0 +1,46 @@
+{ stdenv
+, git
+, pythonPackages
+, fetchgitPrivate
+, cmake
+, hdf5
+, highfive
+}:
+
+let
+    # create a python environment with numpy for numpy bindings tests
+    python_test_env = pythonPackages.python.buildEnv.override {
+      extraLibs = [
+        pythonPackages.cython
+        pythonPackages.numpy
+      ];
+
+    };
+in
+  stdenv.mkDerivation rec {
+    name = "morphio-${version}";
+    version = "0.9.1";
+
+    src = fetchgitPrivate {
+      url = "git@github.com:BlueBrain/morphio.git";
+      rev = "c557a06e0867b4e9befb2095d802cc42d99a8ded";
+      sha256 = "0bx97kbfaysgxn7caf8vagyyfwyrldaybgvsd3d68spyldk6wmqd";
+    };
+
+    buildInputs = [
+      cmake
+      hdf5
+      git
+      stdenv
+    ];
+
+    nativeBuildInputs = [ python_test_env ];
+
+    preConfigure = ''
+	# add setuptools to the path
+	# and fix the date issue with setuptools (https://github.com/NixOS/nixpkgs/issues/270 )
+	export PYTHONPATH=${pythonPackages.bootstrapped-pip}/lib/${pythonPackages.python.libPrefix}/site-packages:$PYTHONPATH
+   '';
+
+    enableParallelBuilding = true;
+ }

--- a/bbp/nse/morphio-python
+++ b/bbp/nse/morphio-python
@@ -1,0 +1,26 @@
+{ stdenv
+, git
+, pythonPackages
+, fetchgitPrivate
+, cmake
+, hdf5
+, highfive
+}:
+
+pythonPackages.buildPythonPackage rec {
+    name = "morphio-python-${version}";
+    version = "0.9.1";
+
+    src = fetchgitPrivate {
+      url = "git@github.com:BlueBrain/morphio.git";
+      rev = "c557a06e0867b4e9befb2095d802cc42d99a8ded";
+      sha256 = "0bx97kbfaysgxn7caf8vagyyfwyrldaybgvsd3d68spyldk6wmqd";
+    };
+
+    buildInputs = [
+      cmake
+      hdf5
+      git
+      stdenv
+    ];
+ }


### PR DESCRIPTION
MorphIO is a shared library with its python bindings.

Ideally I'd like to put them all in the same package but I don't know how to merge the stdenv.mkDerivation and the pythonPackages.buildPythonPackage task