### PR TITLE
parquet-converters: add proper MPI support

### DIFF
--- a/bbp/default.nix
+++ b/bbp/default.nix
@@ -514,6 +514,11 @@ let
 
         };
 
+        syntool-phdf5 = callPackage ./hpc/syntool {
+            hdf5 = phdf5;
+            useMPI = true;
+        };
+
         highfive = callPackage ./hpc/highfive {
 
         };

--- a/bbp/hpc/parquet_converters/default.nix
+++ b/bbp/hpc/parquet_converters/default.nix
@@ -9,7 +9,7 @@
 , parquet-cpp
 , phdf5
 , snappy
-, syntool
+, syntool-phdf5
 , thrift
 , zstd }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   name = "parquet-converters-${version}";
   version = "0.1.0";
 
-  buildInputs = [ arrow boost highfive-phdf5 mpiRuntime parquet-cpp phdf5 snappy syntool thrift zstd ];
+  buildInputs = [ arrow boost highfive-phdf5 mpiRuntime parquet-cpp phdf5 snappy syntool-phdf5 thrift zstd ];
 
   nativeBuildInputs = [
     cmake

--- a/bbp/hpc/syntool/default.nix
+++ b/bbp/hpc/syntool/default.nix
@@ -7,6 +7,7 @@
 , highfive
 , pandoc
 , python
+, useMPI ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -21,6 +22,8 @@ stdenv.mkDerivation rec {
   };
   cmakeFlags =  [
     "-DSYNAPSE_TOOL_DOCUMENTATION:BOOL=ON"
+  ] ++ stdenv.lib.optional useMPI [
+    "-DSYNTOOL_WITH_MPI=ON"
   ];
 
   buildInputs = [


### PR DESCRIPTION
Synapse-tool did not have proper MPI support enabled. Fix that.