### PR TITLE
parquet-converters: 0.1.0 → 0.1.1

### DIFF
--- a/bbp/hpc/parquet_converters/default.nix
+++ b/bbp/hpc/parquet_converters/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation rec {
   name = "parquet-converters-${version}";
-  version = "0.1.0";
+  version = "0.1.1";
 
   buildInputs = [ arrow boost highfive-phdf5 mpiRuntime parquet-cpp phdf5 snappy syntool-phdf5 thrift zstd ];
 
@@ -25,8 +25,8 @@ stdenv.mkDerivation rec {
 
   src = fetchgitPrivate {
     url = config.bbp_git_ssh + "/building/ParquetConverters";
-    rev = "82b5d8d287f68c8c8bd6868846a884b6d7e4e532";
-    sha256 = "02il97zs614khd8mlgczgi2vzgy5y76rs3674gpl8spx7cpwhv3h";
+    rev = "f37f628cf91e3cb9cbf322cab369c5a80b965796";
+    sha256 = "1qq4l0lf8chk04pasmmzyqaivx2n94yaxq2bb5sdnj1yswr6j5lh";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
Minor updates to output, hopefully more informative.