### PR TITLE
- Finally support Tensorflow 1.8.0 from scratch

### DIFF
--- a/bbp/modules/default.nix
+++ b/bbp/modules/default.nix
@@ -1497,6 +1497,7 @@ let
                pythonPkgs.kiwisolver
                pythonPkgs.markupsafe
                pythonPkgs.matplotlib
+               pythonPkgs.kiwisolver
                pythonPkgs.memory_profiler
                pythonPkgs.numexpr
                pythonPkgs.packaging
@@ -1576,6 +1577,7 @@ let
                pythonPkgs.kiwisolver
                pythonPkgs.markupsafe
                pythonPkgs.matplotlib
+               pythonPkgs.kiwisolver
                pythonPkgs.memory_profiler
                pythonPkgs.numexpr
                pythonPkgs.packaging

--- a/patches/additionalPythonPackages/default.nix
+++ b/patches/additionalPythonPackages/default.nix
@@ -8,8 +8,7 @@ let
 
     self = pythonPackages;
 
-in
- rec {
+    pythonPackageAdditionals = rec {
 
     # For a given list of python modules
     # return all there dependencies
@@ -542,7 +541,8 @@ in
       inherit (pkgs.linuxPackages) nvidia_x11;
       cudatoolkit = pkgs.cudatoolkit9;
       cudnn = pkgs.cudnn_cudatoolkit9;
-      inherit tensorflow-tensorboard absl-py;
+      nccl = pkgs.nccl;
+      pythonPackages = allPythonPackages;
     };
 
     absl-py = pythonPackages.buildPythonPackage rec {
@@ -567,6 +567,56 @@ in
         maintainers = with stdenv.lib.maintainers; [ danharaj ];
       };
     };
+
+    astunparse = pythonPackages.buildPythonPackage rec {
+      pname = "astunparse";
+      version = "1.5.0";
+      name = "${pname}-${version}";
+
+      src = pkgs.fetchurl {
+        url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
+        sha256 = "1kc9lm2jvfcip3z8snj04dar5a9jh857a704m6lvcv4xclm3rpsm";
+      };
+
+      doCheck = false;
+
+      propagatedBuildInputs = with self; [ six ];
+
+    };
+
+
+
+    gast = pythonPackages.buildPythonPackage rec {
+      pname = "gast";
+      version = "0.2.0";
+      name = "${pname}-${version}";
+
+      src = pkgs.fetchurl {
+        url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
+        sha256 = "0c296xm1vz9x4w4inmdl0k8mnc0i9arw94si2i7pglpc461r0s3h";
+      };
+
+      propagatedBuildInputs = with self; [ six simplegeneric astunparse ];
+
+    };
+
+    grpcio = pythonPackages.buildPythonPackage rec {
+      pname = "grpcio";
+      version = "1.12.1";
+      name = "${pname}-${version}";
+
+      src = pkgs.fetchurl {
+        url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
+        sha256 = "03prydm3m02krin778gwcyvlagsnfki4j8fd6rjm5a4ss3gslkzi";
+      };
+
+      propagatedBuildInputs = with self; [ six ] ++ stdenv.lib.optionals ( ! isPy3k ) [ futures enum34 ];
+
+    };
+
+
+
+
 
 
   tensorflowWithoutCuda = tensorflow.override {
@@ -1096,4 +1146,10 @@ EOF
     };
   };
 
-}
+  };
+
+   allPythonPackages = self // pythonPackageAdditionals;
+
+
+  in
+	pythonPackageAdditionals

--- a/patches/additionalPythonPackages/tensorflow-tensorboard/default.nix
+++ b/patches/additionalPythonPackages/tensorflow-tensorboard/default.nix
@@ -1,10 +1,12 @@
 { stdenv, lib, fetchPypi, buildPythonPackage, isPy3k
 , bleach_1_5_0
+, bleach
 , numpy
 , werkzeug
 , protobuf
 , markdown
 , futures
+, html5lib_0_9999999
 }:
 
 # tensorflow is built from a downloaded wheel, because
@@ -13,23 +15,24 @@
 
 buildPythonPackage rec {
   pname = "tensorflow-tensorboard";
-  version = "1.5.1";
+  version = "1.8.0";
   name = "${pname}-${version}";
   format = "wheel";
 
   src = fetchPypi ({
-    pname = "tensorflow_tensorboard";
+    pname = "tensorboard";
     inherit version;
     format = "wheel";
   } // (if isPy3k then {
     python = "py3";
-    sha256 = "1cydgvrr0s05xqz1v9z2wdiv60gzbs8wv9wvbflw5700a2llb63l";
+    sha256 = "0vm366znpzghp4rm8zxmjy6a7v5q380nrs790v8prl6hry5wqxkp";
   } else {
     python = "py2";
-    sha256 = "0dhljddlirq6nr84zg4yrk5k69gj3x2abb6wg3crgrparb6qbya7";
+    sha256 = "09c7yrcigx9wibv9i7n76ww2fppj9dp5f51m5k5r6r8s4vcs8l96";
   }));
 
-  propagatedBuildInputs = [ bleach_1_5_0 numpy werkzeug protobuf markdown ] ++ lib.optional (!isPy3k) futures;
+  propagatedBuildInputs = [ numpy werkzeug protobuf markdown bleach_1_5_0 ] 
+			   ++ lib.optionals (!isPy3k) [ futures ] ;
 
   meta = with stdenv.lib; {
     description = "TensorFlow's Visualization Toolkit";

--- a/patches/additionalPythonPackages/tensorflow/bin.nix
+++ b/patches/additionalPythonPackages/tensorflow/bin.nix
@@ -19,12 +19,12 @@
 
 buildPythonPackage rec {
   pname = "tensorflow";
-  version = "1.5.0";
+  version = "1.8.0";
   format = "wheel";
 
   src = fetchurl {
     url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-${version}-py3-none-any.whl";
-    sha256 = "1mapv45n9wmgcq3i3im0pv0gmhwkxw5z69nsnxb1gfxbj1mz5h9m";
+    sha256 = "2mapv45n9wmgcq3i3im0pv0gmhwkxw5z69nsnxb1gfxbj1mz5h9m";
   };
 
   propagatedBuildInputs = [ numpy six protobuf absl-py ]

--- a/patches/default.nix
+++ b/patches/default.nix
@@ -425,6 +425,9 @@ let
 
 	yo = callPackage ./yo {
 	};
+
+	nccl = callPackage ./nccl {
+	};
     };
 
     additionalPythonPackages = MergePkgs.callPackage ./additionalPythonPackages ({

--- a/patches/nccl/default.nix
+++ b/patches/nccl/default.nix
@@ -1,0 +1,40 @@
+{
+  python,
+  pkgconfig,
+  fetchFromGitHub,
+  cudatoolkit,
+  utillinux,
+  stdenv
+}:
+
+stdenv.mkDerivation rec {
+  name = "nccl-${version}";
+  version = "1.3.4-1";
+
+  src = fetchFromGitHub {
+    owner = "nvidia";
+    repo = "nccl";
+    rev = "286916a1a37ca1fe8cd43e280f5c42ec29569fc5";
+    sha256 = "18niy7syfmyin03lmzrzwxhq1zip8zgv3c80fx98d0iv3cpqf8ss";
+  };
+
+  configurePhase = ''
+	set -x
+	export CUDA_HOME="${cudatoolkit}"
+	export CUDA_LIB='${cudatoolkit.lib}/lib'
+	mkdir -p $out
+	export PREFIX=$out
+  '';
+
+
+  buildInputs = [
+    cudatoolkit
+  ];
+
+  nativeBuildInputs = [
+    python
+    pkgconfig
+    utillinux
+  ];
+
+}


### PR DESCRIPTION
- Due to missed update on sha256, TF was never built properly from 1.8.0 even after Tristan patch
- Building Tensorflow from source in 1.8.0 requires several tweak and synchronized version update with TF-board
- Enforcing compilation flags DO NOT work with Bazel, We pass then directly by the compiler wrapper to do it
- Add several minor packages required for TF building
- Enable AVX instruction set by default
- Re-enforce the build to compensate Bazel complete crappyness