### PR TITLE
spykfunc: 0.10.1 → 0.10.2

### DIFF
--- a/bbp/hpc/spykfunc/default.nix
+++ b/bbp/hpc/spykfunc/default.nix
@@ -41,7 +41,7 @@ in
 
   stdenv.mkDerivation rec {
     name = "spykfunc-${version}";
-    version = "0.10.1";
+    version = "0.10.2";
     meta = {
       description = "New Functionalizer implementation on top of Spark";
       longDescription = ''
@@ -65,8 +65,8 @@ in
     };
     src = fetchgitPrivate {
       url = config.bbp_git_ssh + "/building/Spykfunc";
-      rev = "db2641fd05861efe1ee4bccb39bd9122c4012e19";
-      sha256 = "1bd1awkddcsxvmwkxvg1cjpd51az9gfylf67dabz21vmri4218l0";
+      rev = "e2c587f0aa51a89bf68eb7c1bae2afd5d372cbdb";
+      sha256 = "1j9xyhyvahiiz713w4pvffv66fi50s4lps72r4rxc5h1p8mmn39r";
     };
     buildInputs = [ boost hdf5 highfive ];
     nativeBuildInputs = [

--- a/patches/additionalPythonPackages/default.nix
+++ b/patches/additionalPythonPackages/default.nix
@@ -684,12 +684,12 @@ in
   };
 
   sparkmanager = pythonPackages.buildPythonPackage rec {
-    version = "0.5.8";
+    version = "0.6.0";
     pname = "sparkmanager";
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "0ib98xrjppvyhy1x45f96hpdpzlsfyqp99r7hvhlbwd020d65m53";
+      sha256 = "0m6vf637bx8jbyv1cgpfyk28kqdb8iaipavz10zm62v988lm9alq";
     };
 
     preConfigure = ''


### PR DESCRIPTION
Contains fixes based on feedback of @arsenius7:

* move all caches to the output directory
* checkpoints will use HDFS automatically