### PR TITLE
Fix voxcell failing tests during nix-build

### DIFF
--- a/bbp/default.nix
+++ b/bbp/default.nix
@@ -345,6 +345,10 @@ let
         voxcell = callPackage ./nse/voxcell {
         };
 
+        voxcell-py3 = callPackage ./nse/voxcell {
+            pythonPackages = python3Packages;
+        };
+
         entity-management = callPackage ./nse/entity-management {
         };
 

--- a/bbp/nse/voxcell/default.nix
+++ b/bbp/nse/voxcell/default.nix
@@ -17,6 +17,7 @@ pythonPackages.buildPythonPackage rec {
 
     buildInputs = with pythonPackages; [
         nose
+        mock
     ];
 
     propagatedBuildInputs = with pythonPackages; [
@@ -31,4 +32,8 @@ pythonPackages.buildPythonPackage rec {
         scipy
         six
     ];
+
+    checkPhase = ''
+        nosetests tests
+    '';
 }


### PR DESCRIPTION
as it was calling 'unittest' instead of 'nose'