### PR TITLE
Make 'python<X>-light' subset of 'python<X>-full' module

### DIFF
--- a/bbp/modules/default.nix
+++ b/bbp/modules/default.nix
@@ -1528,7 +1528,7 @@ let
                pkgs.bbp-virtualenv
                pythonPkgs.pip
             ];
-            conflicts = [ python27-full python36-full python36-light ] ++ conflicts-modules;
+            conflicts = [ python36-light python36-full ] ++ conflicts-modules;
             dependencies = [ nss-wrapper manylinux1-python ];
         };
 
@@ -1597,8 +1597,8 @@ let
                pythonPkgs.six
                pythonPkgs.tables
             ];
-            conflicts = [ python27-light python36-full python36-light ] ++ conflicts-modules;
-            dependencies = [ nss-wrapper gcc manylinux1-python ];
+            conflicts = [ python36-light python36-full ] ++ conflicts-modules;
+            dependencies = [ python27-light gcc ];
         };
 
         python36-light = with pkgs; pkgs.envModuleGen rec {
@@ -1670,8 +1670,8 @@ let
                pythonPkgs.six
                pythonPkgs.tables
             ];
-            conflicts = [ python27-light python27-full python36-light ] ++ conflicts-modules;
-            dependencies = [ nss-wrapper gcc manylinux1-python ];
+            conflicts = [ python27-light python27-full ] ++ conflicts-modules;
+            dependencies = [ python36-light gcc ];
         };
 
         cython = pkgs.envModuleGen rec {


### PR DESCRIPTION
The downside of specifying `python<X>-[light|full]` as Python modules dependency, is that now we have conflicts between `python<X>-light` and `python<X>-full`.

This is a naive attempt to address it; since at first glance `python<X>-light` and `python<X>-full` should not conflict with each other.